### PR TITLE
Minor version bump 0.3.0 => 0.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1-slim
-ARG MDBOOK_VERSION="0.3.0"
+ARG MDBOOK_VERSION="0.3.5"
 LABEL maintainer="mps299792458@gmail.com" \
       version=$MDBOOK_VERSION
 


### PR DESCRIPTION
This branch bumps the version up. 

Any concerns with this?