### PR TITLE
Upgrade mdBook from 0.3.5 to 0.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1-slim
-ARG MDBOOK_VERSION="0.3.5"
+ARG MDBOOK_VERSION="0.3.6"
 LABEL maintainer="mps299792458@gmail.com" \
       version=$MDBOOK_VERSION
 


### PR DESCRIPTION
mdBook 0.3.6 has been released. ([CHANGELOG](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-036))

This pull request upgrades mdBook from 0.3.5 to 0.3.6.
