### PR TITLE
Bump to 0.4.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1-slim
-ARG MDBOOK_VERSION="0.4.6"
+ARG MDBOOK_VERSION="0.4.10"
 LABEL maintainer="mps299792458@gmail.com" \
       version=$MDBOOK_VERSION
 


### PR DESCRIPTION
Bump to the latest version: 0.4.10 https://github.com/rust-lang/mdBook/releases/tag/v0.4.10